### PR TITLE
Suggestion: Add vim motion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ vim.keymap.set("v", "<leader>g,", function() require("llm").prompt({ replace = f
 vim.keymap.set("v", "<leader>g.", function() require("llm").prompt({ replace = true, service = "openai" }) end)
 
 -- keybinds to support vim motions
-vim.keymap.set("n", "g,", function() require("llm").prompt_range_operator({ replace = false, service = "groq" }) end)
-vim.keymap.set("n", "g.", function() require("llm").prompt_range_operator({ replace = true, service = "groq" }) end)
+vim.keymap.set("n", "g,", function() require("llm").prompt_operatorfunc({ replace = false, service = "groq" }) end)
+vim.keymap.set("n", "g.", function() require("llm").prompt_operatorfunc({ replace = true, service = "groq" }) end)
 ```
 
 ### Roadmap

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ vim.keymap.set("v", "<leader>.", function() require("llm").prompt({ replace = tr
 vim.keymap.set("n", "<leader>g,", function() require("llm").prompt({ replace = false, service = "openai" }) end)
 vim.keymap.set("v", "<leader>g,", function() require("llm").prompt({ replace = false, service = "openai" }) end)
 vim.keymap.set("v", "<leader>g.", function() require("llm").prompt({ replace = true, service = "openai" }) end)
+
+-- keybinds to support vim motions
+vim.keymap.set("n", "g,", function() require("llm").prompt_range_operator({ replace = false, service = "groq" }) end)
+vim.keymap.set("n", "g.", function() require("llm").prompt_range_operator({ replace = true, service = "groq" }) end)
 ```
 
 ### Roadmap

--- a/lua/llm.lua
+++ b/lua/llm.lua
@@ -262,7 +262,7 @@ function M.get_visual_selection()
 	local _, erow, ecol = unpack(vim.fn.getpos("."))
 
 	-- visual line mode
-	if vim.fn.mode() == "V" then
+	if vim.fn.mode() == "V" or vim.fn.mode() == "n" then
 		if srow > erow then
 			return vim.api.nvim_buf_get_lines(0, erow - 1, srow, true)
 		else
@@ -309,6 +309,19 @@ function M.create_llm_md()
 		vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
 		vim.api.nvim_win_set_buf(0, buf)
 	end
+end
+
+-- For running prompt on a range of text via vim motions.
+function M.prompt_operatorfunc(opts)
+  local old_func = vim.go.operatorfunc -- backup previous reference
+  -- set a globally callable object/function
+  _G.op_func_llm_prompt = function()
+    require("llm").prompt(opts)
+    vim.go.operatorfunc = old_func -- restore previous opfunc
+    _G.op_func_llm_prompt = nil -- deletes itself from global namespace
+  end
+  vim.go.operatorfunc = 'v:lua.op_func_llm_prompt'
+  vim.api.nvim_feedkeys('g@', 'n', false)
 end
 
 return M


### PR DESCRIPTION
This adds a new function `prompt_operatorfunc`, which can be used as a vim operatorfunc. With the example bindings, this lets you use the prompt function with vim motions.

For example, from normal mode, you can do:
- `g,ip` to send a whole paragraph
- `g,i"` to send everything inside a quoted string
- if your LSP defines functions as a text object you could do: `g,if` to send the contents of a function.